### PR TITLE
Clarified the tutorial readme files based on some feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ When installing maana CLI, make sure the version is the same as your Maana clust
 **Requirements:** Node.js 8+ and graphql-cli
 
 ```sh
-# Installing the CLI for Maaana 3.1.0
-npm i -g graphql-cli graphql-cli-maana@3.1.0
+# Installing the CLI for the Maaana 3.1.0 release
+npm i -g graphql-cli graphql-cli-maana@3.1.0-release
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,7 +10,9 @@ It is best to make a copy of this repo (delete the .git folder to detach it from
 
 ## Installation
 
+```sh
 npm i -g graphql-cli graphql-cli-maana
+```
 
 ## Setup
 
@@ -31,7 +33,7 @@ To create a configuration from scratch, create a CKG project and GraphQL endpoin
 gql init
 ? Enter project name (Enter to skip): ckg
 ? Local schema file path: ckg.graphql
-? Endpoint URL (Enter to skip): https://qtraining01.knowledge.maana.io:8443/graphql
+? Endpoint URL (Enter to skip): https://<maana host>:8443/graphql
 ? Name of this endpoint, for e.g. default, dev, prod: (default)
 ? Subscription URL (Enter to skip):
 ? Do you want to add other endpoints? No
@@ -45,7 +47,7 @@ About to write to /home/me/maana/training/.graphqlconfig:
       "schemaPath": "ckg.graphql",
       "extensions": {
         "endpoints": {
-          "default": "https://qtraining01.knowledge.maana.io:8443/graphql"
+          "default": "https://<maana host>:8443/graphql"
         }
       }
     }
@@ -55,11 +57,11 @@ About to write to /home/me/maana/training/.graphqlconfig:
 ? Is this ok? Yes
 ```
 
-### Authentication with Maana
+## Authentication with Maana
 
 Maana endpoints require a valid (authenticated) user in order to prevent unauthorized access.
 
-### Maana Q v3.1.0 and later
+### <a name="v3.1.0"></a>Maana Q v3.1.0 and later
 
 After creating a new `.graphqlconfig` file connecting to a Maana API endpoint:
 * Login to the Maana Knowledge Portal
@@ -85,7 +87,7 @@ After creating a new `.graphqlconfig` file connecting to a Maana API endpoint:
 * When you want to run the CLI against the Maana API in a different terminal window you will need to run `gql env` again.
 * If your authentication token expires you can run `gql mrefreshauth` to refresh the authentication token, when the Maana API is configured to allow the refreshing of authentication tokens.
 
-### Maana Q v3.0.5
+### <a name="v3.0.5"></a>Maana Q v3.0.5
 
 After creating a new project connecting to a Maana endpoint, you will need to setup the project to add an authentication header to the requests.
 
@@ -98,17 +100,17 @@ After creating a new project connecting to a Maana endpoint, you will need to se
 
 ```sh
 # *nix based systems
-export AUTH_TOKEN_ENV=<paste auth token here>
+export MAANA_AUTH_TOKEN=<paste auth token here>
 ```
 
 ```bat
 rem Windows command line
-set AUTH_TOKEN_ENV=<paste auth token here>
+set MAANA_AUTH_TOKEN=<paste auth token here>
 ```
 
 ```ps1
 # Windows power shell
-$Env:AUTH_TOKEN_ENV = "<paste auth token here>"
+$Env:MAANA_AUTH_TOKEN = "<paste auth token here>"
 ```
 
 Add the authorization header to the Maana endpoint:
@@ -118,11 +120,11 @@ Add the authorization header to the Maana endpoint:
       "schemaPath": "ckg.graphql",
        "extensions": {
          "endpoints": {
--           "default": "https://qtraining01.knowledge.maana.io:8443/graphql"
+-           "default": "https://<maana host>:8443/graphql"
 +           "default": {
-+             "url": "https://qtraining01.knowledge.maana.io:8443/graphql",
++             "url": "https://<maana host>:8443/graphql",
 +             "headers": {
-+               "Authorization": "Bearer ${env:AUTH_TOKEN_ENV}"
++               "Authorization": "Bearer ${env:MAANA_AUTH_TOKEN}"
 +             }
 +           }
          }
@@ -157,7 +159,7 @@ Execute the **maddsvc** ("add service") command, which takes the **service name*
 
 ```bash
 gql maddsvc Basic -s basic/model.gql -p ckg
-Using endpoint default: {"url":"https://qtraining01.knowledge.maana.io:8443/graphql"}
+Using endpoint default: {"url":"https://<maana host>:8443/graphql"}
 Read file: basic/model.gql size: 136
 Sending query:
   mutation addServiceSource($input: AddServiceSourceInput!) {
@@ -168,13 +170,23 @@ Sending query:
 {"addServiceSource":"1788c00e-3a29-4843-aa56-44ba374cf682"}
 ```
 
-Take note of the generated service id, since we&#39;l add it as a new GraphQL **endpoint** to your CLI configuration.
+Take note of the generated service id, since we&#39;ll add it as a new GraphQL **endpoint** to your CLI configuration.
 
+## Update the Config
+
+Add another project to you graphql config using the following template to build your service url. Make sure that your url ends in `/graphql`.
+
+Template:
+```
+https://<maana host>:8443/service/<service id>/graphql
+```
+
+Command:
 ```bash
 gql add-project
 ? Enter project name for new project: basic
 ? Local schema file path: basic/schema.graphql
-? Endpoint URL (Enter to skip): https://qtraining01.knowledge.maana.io:8443/service/1788c00e-3a29-4843-aa56-44ba374cf682/graphql
+? Endpoint URL (Enter to skip): <service url>
 ? Name of this endpoint, for e.g. default, dev, prod: (default)
 ? Subscription URL (Enter to skip):
 ? Do you want to add other endpoints? No
@@ -183,26 +195,13 @@ Adding the following endpoints to your config:  basic
 ? Is this ok? Yes
 ```
 
-Again, we need to add the authorization header:
+Again, we need to add the authorization header.
+* In Maana Q 3.1.0 or later just run the `gql maddheaders` command
+* In Maana Q 3.5.0 will require adding it manually, check [here](#v3.0.5) for instructions.
 
-```diff
-     "basic": {
-      "schemaPath": "basic/schema.graphql",
-       "extensions": {
-         "endpoints": {
--           "default": "https://qtraining01.knowledge.maana.io:8443/service/1788c00e-3a29-4843-aa56-44ba374cf682/graphql"
-+           "default": {
-+             "url": "https://qtraining01.knowledge.maana.io:8443/service/1788c00e-3a29-4843-aa56-44ba374cf682/graphql"
-+             "headers": {
-+               "Authorization": "Bearer ${env:AUTH_TOKEN_ENV}"
-+             }
-+           }
-         }
-       }
-     }
-```
+## Introspecting the Service
 
-And retrieve the schema from the **service** , which will populate the schemaPath (i.e., basic/schema.graphql) with the generated schema for your service:
+Only a few types were specified for the **domain model**. Maana adds a set of boilerplate types and operations as part of a fully-managed service. The **schema** for this service can be retrieved by:
 
 ```bash
 gql get-schema -p basic

--- a/drill_prob/README.md
+++ b/drill_prob/README.md
@@ -20,7 +20,7 @@ We have included a `.graphqlconfig` file preconfigured for this tutorial.
 gql init
 ? Enter project name (Enter to skip): ckg
 ? Local schema file path: ckg.graphql
-? Endpoint URL (Enter to skip): https://qtraining01.knowledge.maana.io:8443/graphql
+? Endpoint URL (Enter to skip): https://<maana host>:8443/graphql
 ? Name of this endpoint, for e.g. default, dev, prod: (default)
 ? Subscription URL (Enter to skip):
 ? Do you want to add other endpoints? No
@@ -34,7 +34,7 @@ About to write to /home/me/maana/training/.graphqlconfig:
       "schemaPath": "ckg.graphql",
       "extensions": {
         "endpoints": {
-          "default": "https://qtraining01.knowledge.maana.io:8443/graphql"
+          "default": "https://<maana host>:8443/graphql"
         }
       }
     }
@@ -48,7 +48,7 @@ About to write to /home/me/maana/training/.graphqlconfig:
 
 Maana endpoints require a valid (authenticated) user in order to prevent unauthorized access.
 
-### Maana Q v3.1.0 and later
+### <a name="v3.1.0"></a>Maana Q v3.1.0 and later
 
 After creating a new `.graphqlconfig` file connecting to a Maana API endpoint:
 * Login to the Maana Knowledge Portal
@@ -74,7 +74,7 @@ After creating a new `.graphqlconfig` file connecting to a Maana API endpoint:
 * When you want to run the CLI against the Maana API in a different terminal window you will need to run `gql env` again.
 * If your authentication token expires you can run `gql mrefreshauth` to refresh the authentication token, when the Maana API is configured to allow the refreshing of authentication tokens.
 
-### Maana Q v3.0.5
+### <a name="v3.0.5"></a>Maana Q v3.0.5
 
 After creating a new project connecting to a Maana endpoint, you will need to setup the project to add an authentication header to the requests.
 
@@ -87,17 +87,17 @@ After creating a new project connecting to a Maana endpoint, you will need to se
 
 ```sh
 # *nix based systems
-export AUTH_TOKEN_ENV=<paste auth token here>
+export MAANA_AUTH_TOKEN=<paste auth token here>
 ```
 
 ```bat
 rem Windows command line
-set AUTH_TOKEN_ENV=<paste auth token here>
+set MAANA_AUTH_TOKEN=<paste auth token here>
 ```
 
 ```ps1
 # Windows power shell
-$Env:AUTH_TOKEN_ENV = "<paste auth token here>"
+$Env:MAANA_AUTH_TOKEN = "<paste auth token here>"
 ```
 
 Add the authorization header to the Maana endpoint:
@@ -107,11 +107,11 @@ Add the authorization header to the Maana endpoint:
       "schemaPath": "ckg.graphql",
        "extensions": {
          "endpoints": {
--           "default": "https://qtraining01.knowledge.maana.io:8443/graphql"
+-           "default": "https://<maana host>:8443/graphql"
 +           "default": {
-+             "url": "https://qtraining01.knowledge.maana.io:8443/graphql",
++             "url": "https://<maana host>:8443/graphql",
 +             "headers": {
-+               "Authorization": "Bearer ${env:AUTH_TOKEN_ENV}"
++               "Authorization": "Bearer ${env:MAANA_AUTH_TOKEN}"
 +             }
 +           }
          }
@@ -129,7 +129,7 @@ We can use the GraphQL CLI with the Maana plugin command: `maddsvc` ("add servic
 
 ```bash
 gql maddsvc "Drillng Problems" -s model.gql -p ckg
-Using endpoint default: {"url":"https://qtraining01.knowledge.maana.io:8443/graphql"}
+Using endpoint default: {"url":"https://<maana host>:8443/graphql"}
 Read file: model.gql size: 483
 Sending query:
 
@@ -141,41 +141,34 @@ Sending query:
 {"addServiceSource":"50d759d5-983d-4ea2-9773-20077c9b823e"}
 ```
 
+Take note of the generated service id, since we&#39;ll add it as a new GraphQL **endpoint** to your CLI configuration.
+
 ## Update the Config
 
-The included `.graphqlconfig` already contains a project, `dp`, that specified the schema file and endpoint for this service. However, the service ID needs to be updated to match the output from adding the service (above):
+Add another project to you graphql config using the following template to build your service url. Make sure that your url ends in `/graphql`.
 
-```diff
-     "dp": {
-      "schemaPath": "dp.graphql",
-       "extensions": {
-         "endpoints": {
--           "default": "https://qtraining01.knowledge.maana.io:8443/service/051850b1-f088-46b1-8e35-679f5d2ac84f/graphql"
-+           "default": {
-+             "url": "https://qtraining01.knowledge.maana.io:8443/service/50d759d5-983d-4ea2-9773-20077c9b823e/graphql"
-+             "headers": {
-+               "Authorization": "Bearer ${env:AUTH_TOKEN_ENV}"
-+             }
-+           }
-         }
-       }
-     }
+Template:
+```
+https://<maana host>:8443/service/<service id>/graphql
 ```
 
-**Optionally**, to create this project from scratch:
-
+Command:
 ```bash
 gql add-project
-? Enter project name for new project: dp
-? Local schema file path: dp.graphql
-? Endpoint URL (Enter to skip): https://qtraining01.knowledge.maana.io:8443/service/1788c00e-3a29-4843-aa56-44ba374cf682/graphql
+? Enter project name for new project: db
+? Local schema file path: db/schema.graphql
+? Endpoint URL (Enter to skip): <service url>
 ? Name of this endpoint, for e.g. default, dev, prod: (default)
 ? Subscription URL (Enter to skip):
 ? Do you want to add other endpoints? No
 
-Adding the following endpoints to your config:  dp
+Adding the following endpoints to your config:  db
 ? Is this ok? Yes
 ```
+
+Again, we need to add the authorization header.
+* In Maana Q 3.1.0 or later just run the `gql maddheaders` command
+* In Maana Q 3.5.0 will require adding it manually, check [here](#v3.0.5) for instructions.
 
 ## Introspecting the Service
 


### PR DESCRIPTION
* Replaced the host part of urls with <maana host>, as this will be difference on a per customer basis.
* Fixed the version of the CLI to download for Maana version 3.1.0
* Added more information about creating the service url
* Fixed consistency issues between the tutorials
* general cleanup